### PR TITLE
Adding an `Open in DevZero` Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ bash-tools/perl/perl_cpanm_install.sh setup/cpan-requirements.txt lib/setup/cpan
 ```
 
 ### Contributions
+[![Open in DevZero](https://assets.devzero.io/open-in-devzero.svg)](https://www.devzero.io/dashboard/recipes/new?repo-url=https://github.com/HariSekhon/Spotify-tools)
 
 Patches, improvements and even general feedback are welcome in the form of GitHub pull requests and issue tickets.
 


### PR DESCRIPTION
DevZero is a dev environment platform. Using this link, all contributors to this project will be able to use a DevZero environment as the dev workspace. DevZero supports a free plan that individual contributors to OSS projects can utilize to make the contributions and/or to just test out the project.